### PR TITLE
Added gtk2 for uniform vizualization

### DIFF
--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -23,6 +23,8 @@ parts:
       - python-requests
     organize:
       ../build/wrapper: bin/
+    after:
+      - desktop-gtk2
     install: |
       mkdir -p $SNAPCRAFT_PART_INSTALL/bin
       cp rokugtk.py $SNAPCRAFT_PART_INSTALL/bin/

--- a/wrapper
+++ b/wrapper
@@ -13,4 +13,4 @@ export LIBGL_DEBUG=verbose
 
 export PATH=$PATH:/usr/local/bin
 
-$SNAP/bin/rokugtk.py
+desktop-launch $SNAP/bin/rokugtk.py


### PR DESCRIPTION
Try this to try to fix that the app doesn't look the same when installed as a snap.
Adds references to desktop-gtk2
Wrapper executes desktop-launcher
**NOTE**: this can take a long time to start the first time, just let it go.  Maybe up to a minute.

This is edging near to past my familiarity with snapcraft.

To tell the truth, they look the same to me, so this may not fix it for you.
I'm using just the standard ambiance theme in Ubuntu.